### PR TITLE
[DQL2-26] QA Remediation

### DIFF
--- a/ckanext/ytp/comments/templates/package/comment_list.html
+++ b/ckanext/ytp/comments/templates/package/comment_list.html
@@ -43,7 +43,7 @@
             {% if comment.state != 'deleted' %}
                 {{ comment.content|safe }}
             {% else %}
-                {{ _('This comment was deleted.') }}
+                {% snippet "snippets/comment_deleted.html", comment=comment, show_deleter=True %}
             {% endif %}
             {% if comment.state == 'active' %}
             <ul class="links list-inline">

--- a/ckanext/ytp/comments/templates/snippets/comment_deleted.html
+++ b/ckanext/ytp/comments/templates/snippets/comment_deleted.html
@@ -1,7 +1,7 @@
 <p>
     <strong>
         {{ _('Comment deleted') -}}
-        {%- if comment.deleted_by_user_id %}
+        {%- if show_deleter and comment.deleted_by_user_id %}
             {{ _('by') }}
             {% if 'deleted_user_state' in comment and comment.deleted_user_state == 'deleted' %}
                 {{ comment.deleted_user_login_name }}

--- a/ckanext/ytp/comments/templates/snippets/comment_deleted.html
+++ b/ckanext/ytp/comments/templates/snippets/comment_deleted.html
@@ -1,3 +1,4 @@
+{%- set show_deleter = show_deleter or True -%}
 <p>
     <strong>
         {{ _('Comment deleted') -}}


### PR DESCRIPTION
- Adjusted `snippets/comment_deleted.html` to consider `show_deleter` param when displaying deleted comment message.
- Adjusted base `comments_list.html` to always display deleter's username by default.