### PR TITLE
feature/DQL2-43-Data_Request_Comments-Email_notification_enhancements

### DIFF
--- a/ckanext/ytp/comments/email_notifications.py
+++ b/ckanext/ytp/comments/email_notifications.py
@@ -214,7 +214,8 @@ def notify_admins_and_comment_notification_recipients(owner_org, user, template,
             {
                 'url': get_content_item_link(content_type, content_item_id, comment_id),
                 'content_item_title': util.remove_HTML_markup(content_item_title),
-                'comment_text': util.remove_HTML_markup(comment)
+                'comment_text': util.remove_HTML_markup(comment),
+                'content_type': content_type
             }
         )
 

--- a/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
+++ b/ckanext/ytp/comments/templates/emails/bodies/notification-new-comment.txt
@@ -2,8 +2,8 @@ A comment has been made on the Queensland Government open data portal that may b
 
 To 'Reply' to this comment or to review the thread, follow this link:
 {{ url }}
-
-Dataset title: {{ content_item_title }}
+{% set title_label = 'Dataset title' if content_type == 'dataset' else 'Data request subject' %}
+{{ title_label }}: {{ content_item_title }}
 Comment: {{ comment_text }}
 
 Do not reply to this email.

--- a/test/features/comments.feature
+++ b/test/features/comments.feature
@@ -126,7 +126,7 @@ Feature: Comments
         Then I submit a comment with subject "Test Request" and comment "This is a test data request comment"
         Then I take a screenshot
         When I wait for 5 seconds
-        Then I should receive a base64 email at "dr_admin@localhost" containing "Dataset title: Test Request"
+        Then I should receive a base64 email at "dr_admin@localhost" containing "Data request subject: Test Request"
         And I should receive a base64 email at "dr_admin@localhost" containing "Comment: This is a test data request comment"
 
     @comment-delete


### PR DESCRIPTION
Added content_type to 'notification-new-comment.txt' email template to dynamically switch the title_label for datasets & datarequests